### PR TITLE
In ForeachBlock, allow to pass a {{current:list}} in the keys key value

### DIFF
--- a/noWord/common/NWProcContext.py
+++ b/noWord/common/NWProcContext.py
@@ -75,6 +75,8 @@ class NWProcContext:
         parts = ref.split("/")
         alias = parts[0]
         path = parts[1:]
+        if alias not in source:
+            return None
         resource = source[alias]
         for child in path:
             result = tableRegex.findall(child)
@@ -115,8 +117,15 @@ class NWProcContext:
             cmd = cmds[0]
 
             originalTxt = txt
-            txt = txt.replace("{{%s:%s}}" %
-                              cmd, self.processTextCmd(cmd[0], cmd[1]))
+
+            textProcessed = self.processTextCmd(cmd[0], cmd[1])
+
+            if isinstance(textProcessed, str):
+                txt = txt.replace("{{%s:%s}}" %
+                                  cmd, textProcessed)
+            elif isinstance(textProcessed, list):
+                return textProcessed
+            
             if txt == originalTxt:
                 break
 

--- a/noWord/plugins/ForeachBlock/ForeachBlock.py
+++ b/noWord/plugins/ForeachBlock/ForeachBlock.py
@@ -49,7 +49,13 @@ class ForeachBlock(PluginInterface):
 
         if keys is not None:
             if isinstance(keys, str):
-                keysData = context.getResource(context.resources, keys)
+                text = context.processTextCmds(keys)
+                if isinstance(text, str):
+                    keysData = context.getResource(context.resources, text)
+                elif isinstance(text, list):
+                    keysData = text
+                else:
+                    keysData = []
             elif isinstance(keys, list):
                 keysData = keys
             else:


### PR DESCRIPTION
Here is a YAML example of passing {{current:....}} as the keys for a foreach block:

**test.yaml**


```YAML
test:
  - id: my_test
    name: Test
    version: 1.0.0
    softs:
      - soft_1
      - soft_2
      - soft_3
      - soft_4
      - ...
```

**softs.yaml**

```YAML
softs:
  - id: soft_1
    name: Soft1
    version: 1.0.0
  - id: soft_2
    name: Soft2
    version: 1.0.1
  - id: soft_3
    name: Soft3
    version: 4.0.0
  - id: soft_4
    name: Soft4
    version: 3.2.1
  - id: ...
```

**content.yaml**

```YAML
- type: resource
  alias: test
  filename: test.yaml

- type: resource
  alias: softs
  filename: softs.yaml

- type: foreach
  resource: test/test
  content:
    - type: text
      content: "{{current:name}} {{current:version}}"
    - type: foreach
      resource: softs/softs
      keys: "{{current:softs}}" <--------------------------- This Pull Request allows to do this (it will replace {{current:softs}} by [soft_1, soft_2, soft_3, soft_4, ...] list of the test.yaml file
      content: 
        - type: ...
```