### PR TITLE
Explicitely use the yaml loader

### DIFF
--- a/noWord/common/utils_fs.py
+++ b/noWord/common/utils_fs.py
@@ -52,7 +52,7 @@ def loadYAML(filename):
     filename = os.path.normpath(filename)
     try:
         with open(filename, encoding='utf-8') as data_file:
-            data = yaml.load(data_file)
+            data = yaml.load(data_file, Loader=yaml.FullLoader)
             return data
     except Exception as e:
         print("Could not read yaml file: " + str(e))


### PR DESCRIPTION
This will remove the warning when importing the yaml package