### PR TITLE
Update reportlab version to 3.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-reportlab==3.5.6
+reportlab==3.6.1
 pyyaml==5.4
 pdfrw==0.4
 xmltodict==0.12.0


### PR DESCRIPTION
Actual version of reportlab has errors with Pillow:
AttributeError: module 'PIL.Image' has no attribute 'VERSION'